### PR TITLE
lsmeans patch to avoid summary_emm object

### DIFF
--- a/R/lsmeans.R
+++ b/R/lsmeans.R
@@ -41,7 +41,7 @@ lsmeans.tern_gee_logistic <- function(object,
   )
 
   prop_df <- cbind(
-    as.data.frame(prop_emm)[, c(object$vars$arm, "prob", "SE", "asymp.LCL", "asymp.UCL")],
+    data.frame(confint(prop_emm))[, c(object$vars$arm, "prob", "SE", "asymp.LCL", "asymp.UCL")],
     n = as.list(prop_emm)$extras[, ".wgt."]
   )
   names(prop_df) <- c(object$vars$arm, "prop_est", "prop_est_se", "prop_lower_cl", "prop_upper_cl", "n")

--- a/R/lsmeans.R
+++ b/R/lsmeans.R
@@ -41,7 +41,7 @@ lsmeans.tern_gee_logistic <- function(object,
   )
 
   prop_df <- cbind(
-    data.frame(confint(prop_emm))[, c(object$vars$arm, "prob", "SE", "asymp.LCL", "asymp.UCL")],
+    data.frame(stats::confint(prop_emm))[, c(object$vars$arm, "prob", "SE", "asymp.LCL", "asymp.UCL")],
     n = as.list(prop_emm)$extras[, ".wgt."]
   )
   names(prop_df) <- c(object$vars$arm, "prop_est", "prop_est_se", "prop_lower_cl", "prop_upper_cl", "n")


### PR DESCRIPTION
# Pull Request
This PR patches `lsmeans.tern_gee_logistic` so that it creates a true `data.frame`. The function `emmeans::as.data.frame()` actually creates a `summary_emm` object, which is an extension of `data.frame` with annotations added. A new version of **emmeans** added an `rbind()` method for `summary_emm`, with the result that the `rbind()` call in line 58 of `lsmeans.R` got dispatched to `emmeans::rbind.summary_emm()`, initially causing an error until I fixed it to work around it. 

In this PR, `confint(prop_emm)` creates a `summary_emm` object, so that `data.frame()` turns it into a true `data.frame`. Then the `rbind()` call later on does not get dispatched to **emmeans**, and thus does not require my special work-around code.